### PR TITLE
Fix preview for translated pages

### DIFF
--- a/src/app/(frontend)/next/preview/route.ts
+++ b/src/app/(frontend)/next/preview/route.ts
@@ -69,7 +69,7 @@ export async function GET(
       const docs = await payload.find({
         collection: collection,
         draft: true,
-        locale: path.split('/')[0] as TypedLocale,
+        locale: path.split('/')[1] as TypedLocale,
         where: {
           slug: {
             equals: slug,


### PR DESCRIPTION
Path is passed as "/locale/slug".

Change index of split from 0 to 1 to correctly select locale.